### PR TITLE
Change on the cmakelists for the define of LOGLEVEL_TRACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         Core/Src/main.c
 )
 
+target_compile_definitions(log_common PUBLIC LOGLEVEL_TRACE)
+
 # Add linked libraries
 target_link_libraries(${CMAKE_PROJECT_NAME}
         PRIVATE

--- a/Lib/logger-main-c6abda2e/CMakeLists.txt
+++ b/Lib/logger-main-c6abda2e/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(log_common PRIVATE "etl")
 target_link_libraries(log_common PRIVATE freertos_kernel)
 target_link_libraries(log_common PRIVATE freertos_tasks_headers)
 
-target_compile_definitions(log_common PUBLIC LOGLEVEL_TRACE)
 
 add_library(log_x86 STATIC)
 target_sources(log_x86 PRIVATE "src/Platform/x86/Logger.cpp")


### PR DESCRIPTION
Due to the fact that log_common is a library that is used by multiple components placing the following 
```target_compile_definitions(log_common PUBLIC LOGLEVEL_TRACE)```
in the top level cmakelists is a better practice.  This way, the logging level definition will be applied globally to all targets that link against log_common.